### PR TITLE
Add UrlAbsolute property

### DIFF
--- a/urlpicker/src/UrlPicker.Umbraco/Models/UrlPicker.cs
+++ b/urlpicker/src/UrlPicker.Umbraco/Models/UrlPicker.cs
@@ -13,6 +13,7 @@ namespace UrlPicker.Umbraco.Models
         public TypeData TypeData { get; set;}
 
         public string Url { get; set; }
+        public string UrlAbsolute { get; set; }
         public string Name { get; set; }
         public enum UrlPickerTypes { Url, Content, Media };
     }

--- a/urlpicker/src/UrlPicker.Umbraco/PropertyConverters/UrlPickerValueConverter.cs
+++ b/urlpicker/src/UrlPicker.Umbraco/PropertyConverters/UrlPickerValueConverter.cs
@@ -54,7 +54,7 @@ namespace UrlPicker.Umbraco.PropertyConverters
                             if (urlPicker.TypeData.Content != null)
                             {
                                 urlPicker.Url = urlPicker.TypeData.Content.Url;
-
+                                urlPicker.UrlAbsolute = urlPicker.TypeData.Content.UrlAbsolute();
                                 urlPicker.Name = (urlPicker.Meta.Title.IsNullOrWhiteSpace()) ? urlPicker.TypeData.Content.Name : urlPicker.Meta.Title;
                             }                         
                             break;
@@ -63,13 +63,14 @@ namespace UrlPicker.Umbraco.PropertyConverters
                             if (urlPicker.TypeData.Media != null)
                             {
                                 urlPicker.Url = urlPicker.TypeData.Media.Url;
-
+                                urlPicker.UrlAbsolute = urlPicker.TypeData.Media.UrlAbsolute();
                                 urlPicker.Name = (urlPicker.Meta.Title.IsNullOrWhiteSpace()) ? urlPicker.TypeData.Media.Name : urlPicker.Meta.Title;
                             }
                             break;
 
                         default:
                             urlPicker.Url = urlPicker.TypeData.Url;
+                            urlPicker.UrlAbsolute = urlPicker.TypeData.Url;
                             urlPicker.Name = (urlPicker.Meta.Title.IsNullOrWhiteSpace()) ? urlPicker.TypeData.Url : urlPicker.Meta.Title;
                             break;
                     }


### PR DESCRIPTION
UrlPicker's TypeData has a Url property, but it lacks a UrlAbsolute
property.

Umbraco IPublishedContent has a Url property and a UrlAbsolute() method
(made available in the namespace
Umbraco.Web.PublishedContentExtensions). This commit adds the
UrlAbsolute() fuctionality to the UrlPicker object via a UrlAbsolute
property.
